### PR TITLE
Added Computer Model and Controller

### DIFF
--- a/Controllers/ComputerController.cs
+++ b/Controllers/ComputerController.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BangazonAPI.Data;
+using BangazonAPI.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace BangazonAPI.Controllers
+{
+    // Controller created by MEA
+    [Route("[controller]")]
+    public class ComputerController : Controller
+    {
+        private BangazonAPIContext _context;
+        public ComputerController(BangazonAPIContext ctx)
+        {
+            _context = ctx;
+        }
+
+        // GET url/Computer
+        // Returns List of Computers if any exist
+        [HttpGet]
+        public IActionResult Get()
+        {
+            IQueryable<object> computers = from computer in _context.Computer select computer;
+
+            if (computers == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(computers);
+
+        }
+
+        // GET url/Computer/{id}
+        // Returns a Specific Computer correlating to id
+
+        [HttpGet("{id}", Name = "GetSingleComputer")]
+        public IActionResult Get([FromRoute] int id)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                Computer computer = _context.Computer.Single(m => m.ComputerID == id);
+
+                if (computer == null)
+                {
+                    return NotFound();
+                }
+                
+                return Ok(computer);
+            }
+            catch (System.InvalidOperationException ex)
+            {
+                return NotFound(ex);
+            }
+        }
+
+        // POST url/Computer
+        // Creates a Computer in the database
+
+        [HttpPost]
+        public IActionResult Post([FromBody] Computer newComputer)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            _context.Computer.Add(newComputer);
+            
+            try
+            {
+                _context.SaveChanges();
+            }
+            catch (DbUpdateException)
+            {
+                if (ComputerExists(newComputer.ComputerID))
+                {
+                    return new StatusCodeResult(StatusCodes.Status409Conflict);
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return CreatedAtRoute("GetSingleComputer", new { id = newComputer.ComputerID }, newComputer);
+        }
+
+        private bool ComputerExists(int computerID)
+        {
+          return _context.Computer.Count(e => e.ComputerID == computerID) > 0;
+        }
+        // PUT url/Computer/{id}
+        // Edits a Specific Computer from the database
+        [HttpPut("{id}")]
+        public IActionResult Put(int id, [FromBody] Computer modifiedComputer)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            if (id != modifiedComputer.ComputerID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(modifiedComputer).State = EntityState.Modified;
+
+            try
+            {
+                _context.SaveChanges();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!ComputerExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return new StatusCodeResult(StatusCodes.Status204NoContent);
+        }
+        // DELETE url/Computer/{id}
+        // Removes a specific Computer from the database
+        [HttpDelete("{id}")]
+        public IActionResult Delete(int id)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            Computer computer = _context.Computer.Single(m => m.ComputerID == id);
+            if (computer == null)
+            {
+                return NotFound();
+            }
+
+            _context.Computer.Remove(computer);
+            _context.SaveChanges();
+
+            return Ok(computer);
+        }
+
+    }
+}

--- a/Data/BangazonAPIContext.cs
+++ b/Data/BangazonAPIContext.cs
@@ -20,7 +20,7 @@ namespace BangazonAPI.Data
         public DbSet<PaymentType> PaymentType { get; set; }
         // public DbSet<Department> Department { get; set; }
         // public DbSet<TrainingProgram> TrainingProgram { get; set; }
-        // public DbSet<Computer> Computer { get; set; }
+        public DbSet<Computer> Computer { get; set; }
 
 
         //Sets the DateCreated on the <Customer> to todays date every time a new instance of Customer is added to the Context. 

--- a/Models/Computer.cs
+++ b/Models/Computer.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+
+//Written By: Pair Programmed as a Team. 
+namespace BangazonAPI.Models
+{
+    //Creates a new Computer class
+    //ComputerID is the Primary Key
+
+    public class Computer
+    {
+        [Key]
+        public int ComputerID {get; set;}
+
+        [Required]
+        public DateTime DatePurchased {get; set;}
+
+        public DateTime DateDecomissioned {get; set;}
+
+    }
+}

--- a/Models/Computer.cs
+++ b/Models/Computer.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 
-//Written By: Pair Programmed as a Team. 
+//Written By: MEA 
 namespace BangazonAPI.Models
 {
     //Creates a new Computer class


### PR DESCRIPTION
## DESCRIPTION
Added Computer Model and Controller.
Should be able to Get(single or all), Post, Put, and Delete

## STEPS TO TEST
1. Clone this branch to a local repo
2. In terminal, run `dotnet ef migrations add {migrationName}`, `dotnet ef database update`, `dotnet build` then `dotnet run`
3. Test functionality

A. Method Post Paste: http://localhost:5000/Computer into url section on Postman. Paste `{"DatePurchased": "01-18-1988"}` into the body section. Send request.
Should return:
`{
    "computerID": 1,
    "datePurchased": "1988-01-18T00:00:00",
    "dateDecomissioned": "0001-01-01T00:00:00"
}`
B. Method Get(all) Paste: http://localhost:5000/Computer into url section on Postman. Send request.
Should return:
`{
    "computerID": 1,
    "datePurchased": "1988-01-18T00:00:00",
    "dateDecomissioned": "0001-01-01T00:00:00"
}`
C. Method Get(specific id) Paste: http://localhost:5000/Computer/1 into url section on Postman. Send request.
Should return:
`{
    "computerID": 1,
    "datePurchased": "1988-01-18T00:00:00",
    "dateDecomissioned": "0001-01-01T00:00:00"
}`
D. Method Put Paste: http://localhost:5000/Computer/1 into url section on Postman. Paste 
`{
    "computerID": 1,
    "datePurchased": "2000-01-18T00:00:00",
    "dateDecomissioned": "0001-01-01T00:00:00"
}`
into the body section. Send request.
Should return:
`204 No Content`
E. Method Delete Paste: http://localhost:5000/Computer/1 into url section on Postman. Send Request.
Should Return:
`{
    "computerID": 1,
    "datePurchased": "2000-01-18T00:00:00",
    "dateDecomissioned": "0001-01-01T00:00:00"
}`

## REFERENCE

[Ticket 8](https://github.com/Phat-Taupe-Pests/BangazonAPI/issues/8)

[ERD](https://github.com/Phat-Taupe-Pests/Bangazon) 