### PR TITLE
Chaz model cleanup

### DIFF
--- a/Data/DBInitializer.cs
+++ b/Data/DBInitializer.cs
@@ -198,21 +198,21 @@ namespace BangazonAPI.Data
                 {
                     new Employee { 
                         Name = "Joe Dirt",
-                        DateStarted = new DateTime(),
+                        DateStarted = new DateTime(1988,09,16),
                         JobTitle = "Graphic Designer",
                         IsSupervisor = 0,
                         DepartmentID = departments.Single(x => x.Name == "Marketing").DepartmentID
                     },
                     new Employee { 
                         Name = "Kevin Garvey",
-                        DateStarted = new DateTime(),
+                        DateStarted = new DateTime(1988,09,16),
                         JobTitle = "Head of Accounting",
                         IsSupervisor = 1,
                         DepartmentID = departments.Single(x => x.Name == "Accounting").DepartmentID
                     },
                     new Employee { 
                         Name = "Max Payne",
-                        DateStarted = new DateTime(),
+                        DateStarted = new DateTime(1988,09,16),
                         JobTitle = "Senior Developer",
                         IsSupervisor = 0,
                         DepartmentID = departments.Single(x => x.Name == "IT").DepartmentID

--- a/Models/Customer.cs
+++ b/Models/Customer.cs
@@ -19,9 +19,9 @@ namespace BangazonAPI.Models
         public string FirstName {get; set;}
         [Required]
         public string LastName {get; set;}
-        [Required]
+        // [Required]
         public DateTime? DateCreated {get; set;}
-        [Required]
+        // [Required]
         public DateTime? DateLastInteraction {get; set;}
         [Required]
         public int IsActive {get; set;}

--- a/Models/Employee.cs
+++ b/Models/Employee.cs
@@ -19,7 +19,7 @@ namespace BangazonAPI.Models
         public string Name {get; set;}
         [Required]
         public string JobTitle {get; set;}
-        [Required]
+     
         public DateTime? DateStarted {get; set;}
 
         [Required]

--- a/Models/TrainingProgram.cs
+++ b/Models/TrainingProgram.cs
@@ -20,7 +20,7 @@ namespace BangazonAPI.Models
         public DateTime? DateEnd {get; set;}
 
         [Required]        
-        public int MaxAttendees {get; set;}
+        public int? MaxAttendees {get; set;}
 
 
     }


### PR DESCRIPTION
## DESCRIPTION
Made the MaxAttendees property on TrainingPrograms nullable. 
This way the user will get an error if that property is left off instead of the db auto generating a 0 for that field.

Also made the DateCreated and DateLastInteracted not required in the Employee Model. 
This allows the BangazonAPIContext.cs file to autogenerate todays date for those fields on creation instead of throwing an error when they are not passed in on the POST. 

## STEPS TO TEST
1. Clone this branch to a local repo
2. In terminal, run `dotnet ef migrations add {migrationName}`, `dotnet ef database update`, `dotnet build` then `dotnet run`
3. Test functionality
 * Try posting this 
```
{
  "DateStart":" 2017-09-22",
  "DateEnd" : "2017-09-30"
}
```
to `http://localhost:5000/trainingprogram`
  * You should receive an error

## REFERENCE

[Ticket](https://github.com/Phat-Taupe-Pests/BangazonAPI/issues/39)

### Files affected
Models/TrainingProgram.cs